### PR TITLE
Addresses #41, Allows Arbirtary Stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Features
 * ✔ Snippets
   * ✔ Class/interface/trait
 * ✔ Dynamic configuration
+* ✔ Index additional stubs
 
 Unimplemented (yet?):
 
@@ -122,6 +123,7 @@ Command line options
   `<level>` can be one of `emergency`, `alert`, `critical`, `error`,
   `warning`, `notice`, `info`, `debug`. Defaults to `info`.
 * `--build-index` - build standard library index instead of starting the server.
+* `--additional-stubs=<file>, ...` - Specify files containing additional stubs to index.
 
 Configuration
 -------------

--- a/src/Tsufeki/Tenkawa/Php/PhpPlugin.php
+++ b/src/Tsufeki/Tenkawa/Php/PhpPlugin.php
@@ -211,6 +211,20 @@ class PhpPlugin extends Plugin
 
         $container->setValue(FileFilter::class, new GlobFileFilter('**/*.php', 'php'), true);
         $container->setValue(FileFilter::class, new GlobRejectDirectoryFilter('{var,app/cache,cache,.git}'), true);
+
+        if (!empty($options['additional.stubs'])) {
+            $stubs = $options['additional.stubs'];
+            if (is_string($stubs)) {
+                $stubs = (array) $options['additional.stubs'];
+            }
+
+            foreach ($stubs as $path) {
+                $path = rtrim($path, '/') . '/';
+            }
+
+            $container->setValue(FileFilter::class, new GlobFileFilter("{$path}**/*.php", 'php'), true);
+        }
+
         $container->setClass(IndexDataProvider::class, ReflectionIndexDataProvider::class, true);
         $container->setClass(ReflectionTransformer::class, StubsReflectionTransformer::class, true);
         $container->setClass(ReflectionProvider::class, IndexReflectionProvider::class);

--- a/src/Tsufeki/Tenkawa/Server/Tenkawa.php
+++ b/src/Tsufeki/Tenkawa/Server/Tenkawa.php
@@ -144,6 +144,7 @@ class Tenkawa
             'log.client' => false,
             'log.level' => LogLevel::INFO,
             'transport.socket' => false,
+            'additional.stubs' => [],
         ];
 
         foreach ($cmdLineArgs as $arg) {
@@ -171,6 +172,9 @@ class Tenkawa
                         continue 2;
                     case '--socket':
                         $options['transport.socket'] = $value;
+                        continue 2;
+                    case '--additional-stubs':
+                        $options['additional.stubs'][] = $value;
                         continue 2;
                 }
             }


### PR DESCRIPTION
- Additional stubs to be indexed can be specified with
`--additional-stubs=<file>,...`
- Multiple files can be specified by passing the argument multiple
times.

Example using stubs from https://github.com/GiacoCorsiglia/wordpress-stubs:

```sh
cd ~
git clone https://github.com/GiacoCorsiglia/wordpress-stubs
php -d memory_limit=512M ~/src/tenkawa/bin/tenkawa.php --build-index --additional-stubs=~/src/wordpress-stubs/wordpress-stubs.php
```