### PR TITLE
Add php-xml as a requirement

### DIFF
--- a/bin/tenkawa.php
+++ b/bin/tenkawa.php
@@ -24,6 +24,7 @@ unset($xdebug);
 $requiredExtensions = [
     'pdo_sqlite' => 2,
     'mbstring' => 3,
+    'xml' => 4,
 ];
 
 foreach ($requiredExtensions as $ext => $errorCode) {


### PR DESCRIPTION
PHPStan needs classes from php-xml to be able to write information inside vscode.